### PR TITLE
Fixing the documentation link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ components in vanilla CSS, JS, and HTML
 
 ##Documentation
 
-The Documentation is at [https://puranjayjain.github.io/md-date-time-picker](https://github.com/PuranjayJain/md-date-time-picker)
+The Documentation is at [https://puranjayjain.github.io/md-date-time-picker](https://puranjayjain.github.io/md-date-time-picker)
 
 ## Browser Support
 


### PR DESCRIPTION
The documentation link in README.md linked to the GitHub page instead of the documentation page.
