### PR TITLE
Center needle better for more fluid motion

### DIFF
--- a/src/scss/component.scss
+++ b/src/scss/component.scss
@@ -330,11 +330,11 @@
 
 .mddtp-picker__selection {
   position: absolute;
-  left: 50%;
+  left: calc(50% - 4px);
   top: calc(50% - 18px);
-  width: 50%;
+  width: calc(50% + 4px);
   font-size: 0;
-  transform-origin: left center;
+  transform-origin: 4px center;
   transition: .3s cubic-bezier(.42, 0, .58, 1);
 
   span {


### PR DESCRIPTION
The needle is off center a little bit, which looks weird when the needle animates. This is because the center of the needle is 8px wide, but the rotation is centered at the left of it. Instead, it needs to be offset by 4px to be at the center of the needle.

The easiest way to see this is in the demo in minute-mode...try dragging the handle around in a circle.

This is my first PR to this repo, and I was a little unclear about a couple things in the PR template:

I made the changes as small as possible. I couldn't tell whether you want people to commit the changes to `dist` as well. There ended up being changes to the js dist file probably due to some other change that hadn't been compiled. Should I change this PR to only include the changes to the source file?

Also, I can't figure out how to run the linters locally. The link provided on the houndci configuration doesn't help either. Is the only way to check the linting to push the code?