### PR TITLE
fakeNeedle not getting set to right position after drag

### DIFF
--- a/src/js/mdDateTimePicker.js
+++ b/src/js/mdDateTimePicker.js
@@ -1252,7 +1252,7 @@ class mdDateTimePicker {
 		 * netTrek
 		 * fixes for iOS - drag
 		 */
-		fakeNeedleDraggabilly.on('pointerUp', function( e ) {
+		let onDragEnd = function ( e ) {
 			let minuteViewChildren = me._sDialog.minuteView.getElementsByTagName('div')
 			let sMinute = 'mddtp-minute__selected'
 			let selectedMinute = document.getElementById(sMinute)
@@ -1282,7 +1282,10 @@ class mdDateTimePicker {
 			}
 			minute.textContent = me._numWithZero(divides)
 			me._sDialog.sDate.minutes(divides)
-		})
+		}
+
+		fakeNeedleDraggabilly.on('pointerUp', onDragEnd);
+		fakeNeedleDraggabilly.on('dragEnd', onDragEnd);
 	}
 
 	/**


### PR DESCRIPTION
After the needle is dragged, the code sets the position to match the position of the circle so that the needle can be dragged again. However, this is currently happening on the `pointerUp` event, and then Draggabilly resets it back to where the user dropped it, which could be near the center of the clock or even outside the clock.

This changes it to the `dragEnd` event which happens after Draggabilly is done changing the position.

An easy way to see what I mean is by changing the color of the fake needle., e.g. by modifying the css in the debugger or with this script:

```javascript
(() => {
  let style = document.createElement('style')
  style.append('.mddtp-picker__circle--fake { background-color: red }')
  document.body.appendChild(style)
})()
```