### PR TITLE
Keep the month and day when you change the year and hide the controls…

### DIFF
--- a/src/js/mdDateTimePicker.js
+++ b/src/js/mdDateTimePicker.js
@@ -909,12 +909,16 @@ class mdDateTimePicker {
     const subtitle = me._sDialog.subtitle
     const currentYear = document.getElementById('mddtp-date__currentYear')
     if (mdDateTimePicker.dialog.view) {
+      me._sDialog.right.style.display = 'none'
+      me._sDialog.left.style.display = 'none'
       viewHolder.classList.add('zoomOut')
       years.classList.remove('mddtp-picker__years--invisible')
       years.classList.add('zoomIn')
       // scroll into the view
       currentYear.scrollIntoViewIfNeeded && currentYear.scrollIntoViewIfNeeded()
     } else {
+      me._sDialog.right.style.display = 'initial'
+      me._sDialog.left.style.display = 'initial'
       years.classList.add('zoomOut')
       viewHolder.classList.remove('zoomOut')
       viewHolder.classList.add('zoomIn')
@@ -1147,6 +1151,10 @@ class mdDateTimePicker {
     el.onclick = function (e) {
       if (e.target && e.target.nodeName === 'LI') {
         const selected = document.getElementById('mddtp-date__currentYear')
+        const subtitle = me._sDialog.subtitle
+        const titleDay = me._sDialog.titleDay
+        const titleMonth = me._sDialog.titleMonth
+
         // clear previous selected
         selected.id = ''
         selected.classList.remove('mddtp-picker__li--current')
@@ -1157,6 +1165,11 @@ class mdDateTimePicker {
         me._switchToDateView(el, me)
         // set the tdate to it
         me._sDialog.tDate.year(parseInt(e.target.textContent, 10))
+        // update temp date object with the date selected
+        me._sDialog.sDate = me._sDialog.tDate.clone();
+        me._fillText(subtitle, me._sDialog.tDate.year());
+        me._fillText(titleDay, me._sDialog.tDate.format('ddd, '));
+        me._fillText(titleMonth, me._sDialog.tDate.format('MMM D'));
         // update the dialog
         me._initViewHolder()
       }

--- a/src/js/mdDateTimePicker.js
+++ b/src/js/mdDateTimePicker.js
@@ -1166,10 +1166,10 @@ class mdDateTimePicker {
         // set the tdate to it
         me._sDialog.tDate.year(parseInt(e.target.textContent, 10))
         // update temp date object with the date selected
-        me._sDialog.sDate = me._sDialog.tDate.clone();
-        me._fillText(subtitle, me._sDialog.tDate.year());
-        me._fillText(titleDay, me._sDialog.tDate.format('ddd, '));
-        me._fillText(titleMonth, me._sDialog.tDate.format('MMM D'));
+        me._sDialog.sDate = me._sDialog.tDate.clone()
+        me._fillText(subtitle, me._sDialog.tDate.year())
+        me._fillText(titleDay, me._sDialog.tDate.format('ddd, '))
+        me._fillText(titleMonth, me._sDialog.tDate.format('MMM D'))
         // update the dialog
         me._initViewHolder()
       }


### PR DESCRIPTION
when to change the year:
Keep the month and day
refresh header information (year, day of the week, month, and day of the month)
hide the controls for next / previous month when you are changing the year.

Note: use equal to the datepicker android.

# Pull Request template

If you want to make a contribution to the project's source code, follow the guide:

1. Make sure to make changes to one file per pr.
2. Make sure it passes all linter checks of the ci. To more about the linter rules go [here](https://houndci.com/configuration)
3. Be precise as to what are you trying to correct in your title and/or comment.
4. Make sure to open a pr to the correct branch.
5. Try to make as little changes as possible to make the diff more readable.
6. Respect the coding guidelines as mentioned in the linter guide.
7. 
