### PR TITLE
Fire events on date selection and month change

### DIFF
--- a/src/js/mdDateTimePicker.js
+++ b/src/js/mdDateTimePicker.js
@@ -1031,7 +1031,7 @@ class mdDateTimePicker {
             selectedDate: moment(currentDate.toDate().getTime())
           }
         })
-        me._sDialog.picker.dispatchEvent(evt);
+        me._sDialog.picker.dispatchEvent(evt)
         if (me._autoClose === true) {
           me._sDialog.ok.onclick()
         }
@@ -1063,8 +1063,8 @@ class mdDateTimePicker {
         // Create a new date object to prevent the user from editing the original date and mess the calendar
         selectedMonth: moment(this._sDialog.tDate.toDate().getTime())
       }
-    });
-    this._sDialog.picker.dispatchEvent(evt);
+    })
+    this._sDialog.picker.dispatchEvent(evt)
   }
 
   _changeMonth () {

--- a/src/js/mdDateTimePicker.js
+++ b/src/js/mdDateTimePicker.js
@@ -1024,6 +1024,15 @@ class mdDateTimePicker {
         me._fillText(titleDay, currentDate.format('ddd, '))
         me._fillText(titleMonth, currentDate.format('MMM D'))
 
+        var evt = new CustomEvent('dateChange', {
+          bubbles: true,
+          detail: {
+            //Create a new date object to prevent the user from editing the original date and mess the calendar
+            selectedDate: moment(currentDate.toDate().getTime())
+          }
+        });
+        me._sDialog.picker.dispatchEvent(evt);
+        
         if (me._autoClose === true) {
           me._sDialog.ok.onclick()
         }
@@ -1049,6 +1058,16 @@ class mdDateTimePicker {
       right.setAttribute('disabled', '')
       right.classList.add('mddtp-button--disabled')
     }
+    
+    var evt = new CustomEvent('monthChange', {
+      bubbles: true,
+      detail: {
+        //Create a new date object to prevent the user from editing the original date and mess the calendar
+        selectedMonth: moment(this._sDialog.tDate.toDate().getTime())
+      }
+    });
+    this._sDialog.picker.dispatchEvent(evt);
+    
   }
 
   _changeMonth () {

--- a/src/js/mdDateTimePicker.js
+++ b/src/js/mdDateTimePicker.js
@@ -1027,12 +1027,11 @@ class mdDateTimePicker {
         var evt = new CustomEvent('dateChange', {
           bubbles: true,
           detail: {
-            //Create a new date object to prevent the user from editing the original date and mess the calendar
+            // Create a new date object to prevent the user from editing the original date and mess the calendar
             selectedDate: moment(currentDate.toDate().getTime())
           }
-        });
+        })
         me._sDialog.picker.dispatchEvent(evt);
-        
         if (me._autoClose === true) {
           me._sDialog.ok.onclick()
         }
@@ -1058,16 +1057,14 @@ class mdDateTimePicker {
       right.setAttribute('disabled', '')
       right.classList.add('mddtp-button--disabled')
     }
-    
     var evt = new CustomEvent('monthChange', {
       bubbles: true,
       detail: {
-        //Create a new date object to prevent the user from editing the original date and mess the calendar
+        // Create a new date object to prevent the user from editing the original date and mess the calendar
         selectedMonth: moment(this._sDialog.tDate.toDate().getTime())
       }
     });
     this._sDialog.picker.dispatchEvent(evt);
-    
   }
 
   _changeMonth () {
@@ -1080,7 +1077,6 @@ class mdDateTimePicker {
     left.onclick = function () {
       moveStep(mRightClass, me._sDialog.previous)
     }
-
     right.onclick = function () {
       moveStep(mLeftClass, me._sDialog.next)
     }


### PR DESCRIPTION
In my project, I had the need to intercept the date change event and the month change event (without waiting for the user to click on OK or CANCEL), so I intercepted the actions and fired the relative event on the picker element (a CustomEvent containing the new date/month selected by the user).

I thought these edits would be useful for you so I opened this PR.