### PR TITLE
Set year picker invisible when year view is not visible

### DIFF
--- a/src/js/mdDateTimePicker.js
+++ b/src/js/mdDateTimePicker.js
@@ -951,11 +951,11 @@ class mdDateTimePicker {
       // Check if the scroll function exists and scroll the container into view
       if (typeof currentYear.scrollIntoViewIfNeeded === 'function') {
         currentYear.scrollIntoViewIfNeeded()
-      } else {
-        setTimeout(() => {
-          this.toggleElementClassName(years, 'mddtp-picker__years--invisible', true)
-        }, 200)
       }
+    } else {
+      setTimeout(() => {
+        this.toggleElementClassName(years, 'mddtp-picker__years--invisible', true)
+      }, 200)
     }
 
     this.toggleElementClassName(title, 'mddtp-picker__color--active', !isInYearView)


### PR DESCRIPTION
This fixes an issue where the year view is not disabled after selecting a year (or switching back to the month view). Therefore, the year view was still processing click events even though it is not visible.

The fix is simply done by moving the corresponding `else` block to the correct `if`.